### PR TITLE
LPP-65016 PrincipalException on the custom 404 page for ignored extensions

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -116,6 +116,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.FullNameGenerator;
 import com.liferay.portal.kernel.security.auth.FullNameGeneratorFactory;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
@@ -6109,8 +6110,24 @@ public class PortalImpl implements Portal {
 				servletContext.getRequestDispatcher(redirect);
 
 			if (requestDispatcher != null) {
-				requestDispatcher.forward(
-					httpServletRequest, httpServletResponse);
+
+				// LPP-65016
+
+				String principalName = PrincipalThreadLocal.getName();
+				PermissionChecker permissionChecker =
+					PermissionThreadLocal.getPermissionChecker();
+
+				try {
+					_initSecurityThreadLocals(httpServletRequest);
+
+					requestDispatcher.forward(
+						httpServletRequest, httpServletResponse);
+				}
+				finally {
+					PrincipalThreadLocal.setName(principalName);
+					PermissionThreadLocal.setPermissionChecker(
+						permissionChecker);
+				}
 			}
 		}
 		else if (exception != null) {
@@ -8128,6 +8145,27 @@ public class PortalImpl implements Portal {
 		Company company = themeDisplay.getCompany();
 
 		return company.getVirtualHostname();
+	}
+
+	private void _initSecurityThreadLocals(
+		HttpServletRequest httpServletRequest) {
+
+		if (Validator.isNotNull(PrincipalThreadLocal.getName())) {
+			return;
+		}
+
+		try {
+			User user = initUser(httpServletRequest);
+
+			PrincipalThreadLocal.setName(user.getUserId());
+
+			PermissionThreadLocal.getPermissionChecker(user, true);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
 	}
 
 	private boolean _isSignedIn(HttpServletRequest httpServletRequest) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPP-65016

Shared for analysis only. This branch is not meant to be merged into `master`; the owning team implements and validates the final fix.

## What Is Being Fixed

With a custom "page not found" configured through `layout.friendly.url.page.not.found`, requesting a missing resource whose name ends with one of the `virtual.hosts.ignore.extensions` suffixes (`.css`, `.gif`, `.ico`, `.jpeg`, `.js`, `.jsp`, `.png`) while signed in logs `com.liferay.portal.kernel.security.auth.PrincipalException: Principal is null` and renders the generic error page instead of the configured one.

`VirtualHostFilter.isFilterEnabled` returns `false` for those suffixes, so the portal never rewrites the URI and the 404 is raised by the container. Tomcat then dispatches to `/errors/code.jsp` under `DispatcherType.ERROR`, and that JSP calls `PortalUtil.sendError(SC_NOT_FOUND, new NoSuchLayoutException(...))`, which forwards to the configured page.

The forwards nested inside that ERROR dispatch never get a filter chain of their own. Tomcat keeps `DispatcherType.ERROR` across them, so `InvokerFilter` handles them and resolves the chain through `InvokerFilter.getOriginalRequestURI`, which for the ERROR dispatcher reads `jakarta.servlet.error.request_uri` — always the original URI. Every dispatch after the 404 is therefore matched against `/missing.png`, which matches neither `/web/*` (`Secure Friendly URL Servlet Filter`) nor `/c/*` (`Secure Main Servlet Filter`). `BaseAuthFilter.initThreadLocals` never runs and `PrincipalThreadLocal` stays empty, while `ThemeDisplay` still carries the real user from the session. The first remote service call made while rendering the theme then fails: `_unstyled/templates/init.ftl:343` evaluates `user.hasMySites()`, which reaches `GroupServiceUtil.getUserSitesGroups` and `BaseServiceImpl.getUserId`.

This is why only signed-in users are affected: `UserImpl.hasMySites` returns early for the guest user, so the guest never reaches the remote service.

Measured on a local bundle at `14c049c9ae9a2`, with `com.liferay.portal.kernel.servlet.filters.invoker.FilterMapping`, `...invoker.InvokerFilterChain`, `...security.auth.PrincipalThreadLocal` and `...security.auth.CompanyThreadLocal` at DEBUG, requesting `/missing.png` with a session cookie:

| Observation | Value |
| --- | --- |
| `PrincipalThreadLocal.setName` calls | 0 |
| `PrincipalThreadLocal.getName` returning `null` | 13 |
| `PortalInstancesFilter` invocations | 4 |
| `ThreadLocalFilter` invocations | 1 (REQUEST only) |
| Distinct URIs the filter chain was resolved against | 1, `/missing.png` |

The last row is the key one: appending an unseen query parameter forces a miss on the `InvokerFilter` chain cache, so `FilterMapping` logs every match decision. All 124 decisions are made against `/missing.png`; none against `/web/error/error404` or `/c/portal/layout`. Removing `.gif`, `.jsp` and `.png` from `virtual.hosts.ignore.extensions` makes the same request succeed, with `SecureFilter has a pattern match with /web/guest/missing.png` followed by `PrincipalThreadLocal setName <userId>`.

Two consequences worth noting for whoever picks this up. Adding `<dispatcher>ERROR</dispatcher>` to the `Secure *` filters in `liferay-web.xml` does not help, because the URI used for matching is still `/missing.png`. And the loss is not a `CompanyThreadLocal.setCompanyId` wiping the `CompanyCentralizedThreadLocal` entries: the principal is never set in the first place.

## How It Is Being Fixed

`PortalImpl.sendError` populates `PrincipalThreadLocal` and `PermissionThreadLocal` from the session user immediately before forwarding, mirroring what `BaseAuthFilter.initThreadLocals` would have done. The guard exits as soon as a filter has already set the principal, so the in-request path — `FriendlyURLServlet` raising `NoSuchLayoutException` — is untouched. `initUser` falls back to the guest user when there is no session, so guest behavior does not change.

Both thread locals are restored in a `finally`. `PrincipalThreadLocal._name` is a short-lived `CompanyCentralizedThreadLocal` and the only thing that clears it is `ThreadLocalFilter.doFilterFinally`, which is mapped to the REQUEST dispatcher alone. Since the ERROR dispatch runs after that `finally`, anything left behind would survive on the pooled thread until the end of the next request and be visible to any URL where `SecureFilter` does not run. The save-and-restore shape follows `PortalInstances.getCompanyId`.

This addresses the custom "page not found" path. The underlying `InvokerFilter.getOriginalRequestURI` behavior is unchanged, so any other render that needs a permission-checked service inside an ERROR dispatch remains exposed.

## Why Are There No Tests?

The owning team implements and validates the final fix, so this branch carries the analysis and a working change to reason about rather than a merge candidate. `PortalImplUnitTest` is the natural home for coverage of `sendError`.

## PR Check

**pr-check: SKIPPED** — shared for analysis only, not a merge candidate. Transaction Usage passed. Source Format fails for one reason unrelated to the code: `JIRAUtil.validateJIRAProjectNames` does not accept `LPP` as a commit-message project prefix, so the commit has to be recreated under an LPD ticket before this can go anywhere near `master`. Full Portal Build, Cross-Module Compile, Baseline and Java Unit Tests were not run; `ant compile` on `portal-impl` succeeds and the formatter reports no violations in the changed file.

<!-- pr-check {"reason": "shared for analysis only, not a merge candidate", "result": "skipped", "sha": "650c6f7d83cf61f004603185d3a73336dbf5bb90"} -->
